### PR TITLE
fix: check for virtual doctype before enqueing again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": {
+      "@4tw/cypress-drag-drop": "^2.2.5",
+      "@cypress/code-coverage": "^3",
+      "@testing-library/cypress": "^10",
+      "@testing-library/dom": "8.17.1",
+      "cypress": "^13.1.0",
+      "cypress-real-events": "^1.7.6"
+    }
+  }

--- a/printnode_integration/__init__.py
+++ b/printnode_integration/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"

--- a/printnode_integration/events.py
+++ b/printnode_integration/events.py
@@ -13,7 +13,7 @@ from . import api
 
 
 def print_via_printnode(doctype, docname, docevent):
-	if frappe.flags.in_import or frappe.flags.in_patch:
+	if frappe.flags.in_import or frappe.flags.in_patch or is_virtual_doctype(doctype):
 		return
 	if not frappe.db.exists(doctype, docname):
 		enqueue(


### PR DESCRIPTION
## Description

- fix: check for virtual doctype before enqueing again
  - frappe.db.exists returns None for virtual doctypes, causing infinite job enqueues for virtual doctypes

## Type of change

- 🟢 Bug fix (change which fixes an issue)
- ⚪ New feature (change which adds functionality)
- ⚪ Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Tests

- [ ] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [ ] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines) (DocType, Field  and Variable naming)
- [x] No Form changes */* My code follows the [Form Design Guidelines](https://github.com/frappe/erpnext/wiki/Form-Design-Guidelines)
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas */* No comments necessary
- [ ] I have made corresponding additions/changes to the documentation
- [x] All business logic and validations are on the server-side */* No business logic or validation changes
- [x] No patches are necessary */* Migration Patches have been added to the correct subdirectory of `/patches` and `patches.txt` have been updated


## User Experience:

N/A
