### PR TITLE
 fix: gate doc-event enqueue on configured Print Node Actions

### DIFF
--- a/printnode_integration/__init__.py
+++ b/printnode_integration/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.11.4"
+__version__ = "0.11.5"

--- a/printnode_integration/events.py
+++ b/printnode_integration/events.py
@@ -74,57 +74,66 @@ def print_via_printnode(doctype, docname, docevent):
 			)
 
 
+PRINT_ACTION_CACHE_KEY = "printnode_active_actions"
+
+
+def _active_print_actions():
+	"""Set of "<doctype>::<print_on>" pairs that have a Print Node Action.
+
+	Cached in redis; rebuilt lazily and invalidated by
+	clear_print_action_cache() whenever Print Node Settings (which owns the
+	Action child table) is saved.
+	"""
+	actions = frappe.cache.get_value(PRINT_ACTION_CACHE_KEY)
+	if actions is None:
+		actions = {
+			f"{d.dt}::{d.print_on}"
+			for d in frappe.get_all("Print Node Action", fields=["dt", "print_on"])
+			if d.dt and d.print_on
+		}
+		frappe.cache.set_value(PRINT_ACTION_CACHE_KEY, actions)
+	return actions
+
+
+def _enqueue_print(doc, docevent):
+	# cheap redis set lookup; filters out the ~all doctypes with no action
+	if f"{doc.doctype}::{docevent}" not in _active_print_actions():
+		return
+	if is_virtual_doctype(doc.doctype):
+		return
+	enqueue(
+		"printnode_integration.events.print_via_printnode",
+		enqueue_after_commit=True,
+		doctype=doc.doctype,
+		docname=doc.name,
+		docevent=docevent,
+		now=True,
+	)
+
+
+def clear_print_action_cache(doc=None, method=None):
+	frappe.cache.delete_value(PRINT_ACTION_CACHE_KEY)
+
+
 def after_insert(doc, handler=None):
-	if not is_virtual_doctype(doc.doctype):
-		enqueue(
-			"printnode_integration.events.print_via_printnode",
-			enqueue_after_commit=True,
-			doctype=doc.doctype,
-			docname=doc.name,
-			docevent="Insert",
-			now=True,
-		)
+	_enqueue_print(doc, "Insert")
 
 
 def on_update(doc, handler=None):
-	if not is_virtual_doctype(doc.doctype):
-		enqueue(
-			"printnode_integration.events.print_via_printnode",
-			enqueue_after_commit=True,
-			doctype=doc.doctype,
-			docname=doc.name,
-			docevent="Update",
-			now=True,
-		)
+	_enqueue_print(doc, "Update")
 
 
 def on_update_after_submit(doc, handler=None):
-	if not is_virtual_doctype(doc.doctype):
-		enqueue(
-			"printnode_integration.events.print_via_printnode",
-			enqueue_after_commit=True,
-			doctype=doc.doctype,
-			docname=doc.name,
-			docevent="UpdateAfterSubmit",
-			now=True,
-		)
+	_enqueue_print(doc, "UpdateAfterSubmit")
 
 
 def on_submit(doc, handler=None):
-	if not is_virtual_doctype(doc.doctype):
-		enqueue(
-			"printnode_integration.events.print_via_printnode",
-			enqueue_after_commit=True,
-			doctype=doc.doctype,
-			docname=doc.name,
-			docevent="Submit",
-			now=True,
-		)
+	_enqueue_print(doc, "Submit")
 
 
 def on_trash(doc, handler=None):
 	if not is_virtual_doctype(doc.doctype):
-		settings = frappe.get_doc("Print Node Settings", "Print Node Settings")
+		settings = frappe.get_cached_doc("Print Node Settings", "Print Node Settings")
 		if not settings.api_key or settings.allow_deletion_for_printed_documents:
 			for print_job in frappe.get_all(
 				"Print Node Job", fields=["name"], filters={"ref_type": doc.doctype, "ref_name": doc.name}

--- a/printnode_integration/hooks.py
+++ b/printnode_integration/hooks.py
@@ -86,7 +86,10 @@ doc_events = {
 		"on_submit": "printnode_integration.events.on_submit",
 		"on_trash": "printnode_integration.events.on_trash",
 		"on_update_after_submit": "printnode_integration.events.on_update_after_submit",
-	}
+	},
+	"Print Node Settings": {
+		"on_update": "printnode_integration.events.clear_print_action_cache",
+	},
 }
 
 # doc_events = {


### PR DESCRIPTION
 fix: gate doc-event enqueue on configured Print Node Actions

The "*" doc_events wildcard ran the print handlers on every document event for every doctype. The handlers only guarded on is_virtual_doctype before calling enqueue(now=True), so each event reloaded the doc and ran a "Print Node Action" existence query — even for doctypes with no action configured. frappe.flags.in_import skipped this for the Data Import tool, but scripted/REST/bulk inserts paid the full cost per row.

Route the four print handlers through a redis-cached set of "<doctype>::<print_on>" pairs so events for unconfigured doctypes short-circuit on a single set lookup (no enqueue, no get_doc, no query). Invalidate the cache when Print Node Settings (owner of the Action child table) is saved. Also use get_cached_doc for the settings singleton in on_trash.